### PR TITLE
K2 process changes

### DIFF
--- a/buildkit/re/deps/git_dep_resolver.cpp
+++ b/buildkit/re/deps/git_dep_resolver.cpp
@@ -28,10 +28,16 @@ namespace re
     {
         if (cache)
         {
-            auto git_ls_remote = [](const re::TargetDependency &, std::string_view url) -> std::vector<std::string> {
+            auto git_ls_remote = [&](const re::TargetDependency &, std::string_view url) -> std::vector<std::string> {
+
                 boost::process::ipstream is; // reading pipe-stream
                 boost::process::child c(boost::process::search_path("git"), "ls-remote", "--refs", "--tags", url.data(),
-                                        boost::process::std_out > is);
+                                        boost::process::std_out > is, boost::process::std_in < stdin);
+
+                while (c.running())
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+                }
 
                 c.wait();
 

--- a/buildkit/re/process_util.cpp
+++ b/buildkit/re/process_util.cpp
@@ -11,21 +11,123 @@
 
 namespace re
 {
-    int RunProcessOrThrow(std::string_view program_name, const fs::path& path, std::vector<std::string> cmdline, bool output, bool throw_on_bad_exit, std::optional<std::string_view> working_directory)
+
+// run_target->module, exe_path, run_args, true, false, working_dir
+#ifdef WIN32
+    int RunProcessOrThrow(std::string_view program_name, const fs::path &path, std::vector<std::string> cmdline,
+                          bool output, bool throw_on_bad_exit, std::optional<fs::path> working_directory)
     {
+        HANDLE hJob = NULL;
+        HANDLE hProcess = NULL;
+        HANDLE hThread = NULL;
+
+        auto finish = [&]() {
+            if (hJob)
+            {
+                ::CloseHandle(hJob);
+                hJob = NULL;
+            }
+
+            if (hProcess)
+            {
+                ::CloseHandle(hProcess);
+                hProcess = NULL;
+            }
+
+            if (hThread)
+            {
+                ::CloseHandle(hThread);
+                hThread = NULL;
+            }
+        };
+
+        try
+        {
+            hJob = CreateJobObjectW(NULL, NULL);
+            if (!hJob)
+                RE_THROW ProcessRunException("{} failed to start: failed to create Win32 job object", program_name);
+
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = {0};
+            jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            if (!SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli)))
+                RE_THROW ProcessRunException("{} failed to start: failed to set Win32 job object information",
+                                             program_name);
+
+            if (!path.empty())
+                cmdline.insert(cmdline.begin(), path.u8string());
+
+            std::wstring args;
+            for (auto &s : cmdline)
+            {
+                args.append(fs::path{s}.wstring());
+                args.append(L" ");
+            }
+
+            STARTUPINFOW info = {sizeof(info)};
+            PROCESS_INFORMATION pi;
+
+            if (::CreateProcessW(NULL, args.data(), nullptr, nullptr, true,
+                                 CREATE_SUSPENDED | CREATE_BREAKAWAY_FROM_JOB, nullptr,
+                                 working_directory ? working_directory->wstring().c_str() : nullptr, &info, &pi))
+            {
+                hProcess = pi.hProcess;
+                hThread = pi.hThread;
+
+                if (!AssignProcessToJobObject(hJob, pi.hProcess))
+                    RE_THROW ProcessRunException("{} failed to start: failed to assign Win32 job object", program_name);
+
+                ::ResumeThread(hThread);
+                ::WaitForSingleObject(hProcess, INFINITE);
+
+                DWORD exit_code = 0;
+                ::GetExitCodeProcess(hProcess, &exit_code);
+
+                if (throw_on_bad_exit && exit_code != 0)
+                {
+                    RE_THROW ProcessRunException("{} failed: exit_code={}", program_name, exit_code);
+                }
+
+                finish();
+                return (int)exit_code;
+            }
+            else
+            {
+                RE_THROW ProcessRunException("{} failed to start: CreateProcessW failed", program_name);
+            }
+        }
+        catch (const ProcessRunException &ex)
+        {
+            finish();
+            throw ex;
+        }
+        catch (const std::exception &ex)
+        {
+            finish();
+            throw ex;
+        }
+    }
+#else
+    int RunProcessOrThrow(std::string_view program_name, const fs::path &path, std::vector<std::string> cmdline,
+                          bool output, bool throw_on_bad_exit, std::optional<fs::path> working_directory)
+    {
+
+        auto working_dir = working_directory->u8string();
+
         reproc::options options;
         options.redirect.parent = output;
-        options.working_directory = working_directory ? working_directory->data() : nullptr;
+        options.working_directory =
+            working_directory ? (decltype(options.working_directory))working_dir.c_str() : nullptr;
 
         if (!path.empty())
             cmdline.insert(cmdline.begin(), path.u8string());
 
         reproc::process process;
-
         auto start_ec = process.start(cmdline, options);
         if (start_ec)
         {
-            RE_THROW ProcessRunException("{} failed to start: {} (ec={})", program_name, start_ec.message(), start_ec.value());
+            RE_THROW ProcessRunException("{} failed to start: {} (ec={})", program_name, start_ec.message(),
+                                         start_ec.value());
         }
 
         auto [exit_code, end_ec] = process.wait(reproc::infinite);
@@ -34,7 +136,8 @@ namespace re
 
         if (end_ec)
         {
-            RE_THROW ProcessRunException("{} failed to run: {} (ec={} exit_code={})", program_name, end_ec.message(), end_ec.value(), exit_code);
+            RE_THROW ProcessRunException("{} failed to run: {} (ec={} exit_code={})", program_name, end_ec.message(),
+                                         end_ec.value(), exit_code);
         }
 
         if (throw_on_bad_exit && exit_code != 0)
@@ -44,69 +147,6 @@ namespace re
 
         return exit_code;
     }
-
-#ifdef WIN32
-    namespace
-    {
-        HANDLE gProcessUtilJob = NULL;
-    }
-
-    int RunProcessOrThrowWindows(std::string_view program_name, std::vector<std::wstring> cmdline, bool output, bool throw_on_bad_exit, std::optional<std::wstring_view> working_directory)
-    {
-        if (!gProcessUtilJob)
-        {
-            if (gProcessUtilJob = CreateJobObjectW(NULL, NULL))
-            {
-                JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = { 0 };
-
-                // Configure all child processes associated with the job to terminate when the
-                jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-
-                if (!SetInformationJobObject(gProcessUtilJob, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli)))
-                    RE_THROW ProcessRunException("{} failed to start: failed to set Win32 job object information", program_name);
-            }
-            else
-            {
-                RE_THROW ProcessRunException("{} failed to start: failed to create Win32 job object", program_name);
-            }
-        }
-
-        std::wstring args;
-
-        for (auto& s : cmdline)
-        {
-            args.append(s);
-            args.append(L" ");
-        }
-
-        STARTUPINFOW info = { sizeof(info) };
-        PROCESS_INFORMATION process;
-
-        if (::CreateProcessW(NULL, args.data(), nullptr, nullptr, true, CREATE_SUSPENDED, nullptr, working_directory ? working_directory->data() : nullptr, &info, &process))
-        {
-            if (!AssignProcessToJobObject(gProcessUtilJob, process.hProcess))
-            {
-                RE_THROW ProcessRunException("{} failed to start: failed to assign Win32 job object", program_name);
-                ::CloseHandle(process.hThread);
-            }
-
-            ::ResumeThread(process.hThread);
-            ::WaitForSingleObject(process.hProcess, INFINITE);
-
-            DWORD exit_code = 0;
-            ::GetExitCodeProcess(process.hProcess, &exit_code);
-
-            if (throw_on_bad_exit && exit_code != 0)
-            {
-                RE_THROW ProcessRunException("{} failed: exit_code={}", program_name, exit_code);
-            }
-
-            return (int)exit_code;
-        }
-        else
-        {
-            RE_THROW ProcessRunException("{} failed to start: CreateProcessW failed", program_name);
-        }
-    }
 #endif
-}
+
+} // namespace re

--- a/buildkit/re/process_util.h
+++ b/buildkit/re/process_util.h
@@ -1,36 +1,28 @@
 #pragma once
-#include <vector>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <optional>
+#include <vector>
 
-#include "fs.h"
+
 #include "error.h"
+#include "fs.h"
+
 
 namespace re
 {
-    int RunProcessOrThrow(
-        std::string_view program_name,
-        const fs::path& path,
-        std::vector<std::string> cmdline,
-        bool output = false,
-        bool throw_on_bad_exit = false,
-        std::optional<std::string_view> working_directory = std::nullopt
-    );
-    
-#ifdef WIN32
-    int RunProcessOrThrowWindows(
-        std::string_view program_name,
-        std::vector<std::wstring> cmdline,
-        bool output = false,
-        bool throw_on_bad_exit = false,
-        std::optional<std::wstring_view> working_directory = std::nullopt
-    );
-#endif
+    int RunProcessOrThrow(std::string_view program_name, const fs::path &path, std::vector<std::string> cmdline,
+                                 bool output, bool throw_on_bad_exit, std::optional<fs::path> working_directory = std::nullopt);
+
+// #ifdef WIN32
+//     int RunProcessOrThrowWindows(std::string_view program_name, std::vector<std::string> cmdline, bool output = false,
+//                                  bool throw_on_bad_exit = false,
+//                                  std::optional<fs::path> working_directory = std::nullopt);
+// #endif
 
     class ProcessRunException : public Exception
     {
     public:
         using Exception::Exception;
     };
-}
+} // namespace re

--- a/buildkit/re/version_impl.h
+++ b/buildkit/re/version_impl.h
@@ -1,6 +1,6 @@
 #pragma once
 namespace re
 {
-    constexpr auto kBuildVersionTag = "v0.1.19-1-ga0f9cf2";
-    constexpr auto kBuildRevision = "a0f9cf2b6eea6522e5f73b2a657ae59199c0b809";
+    constexpr auto kBuildVersionTag = "v0.5.1";
+    constexpr auto kBuildRevision = "c4c1997c5d5bf7d5a2bb1ce4fb99595479e4e5d9";
 }

--- a/compile-commands-gen.py
+++ b/compile-commands-gen.py
@@ -1,0 +1,52 @@
+import json
+import sys
+import os
+
+meta_path = sys.argv[1]
+compile_commands_path = sys.argv[2]
+
+meta = {}
+compile_commands = []
+
+with open(meta_path, 'r') as file:
+    meta = json.load(file)
+
+for path, target in meta['targets'].items():
+    if not 'cxx' in target.keys():
+        continue
+
+    cxx = target['cxx']
+    if not 'sources' in cxx.keys():
+        continue
+
+    compiler = 'clang++'  # target['tools']['compiler']
+    standard = cxx['standard']
+
+    if standard == 'c++latest':
+        standard = 'c++20'
+
+    flags: list[str] = []
+
+    flags += ['-x', 'c++']
+    # flags += ['-std', 'c++']
+    flags.append(f'-std={standard}')
+
+    for include_dir in cxx['include_dirs']:
+        flags.append(f'-I{include_dir}')
+
+    for definition in cxx['definitions']:
+        flags.append(f'-D{definition}')
+
+    for source in cxx['sources'] + (target['unused-sources'] if 'unused-sources' in target.keys() else []):
+        if os.path.splitext(source)[-1].startswith('h'):
+            continue
+
+        command = {
+            'directory': path,
+            'file': source,
+            'arguments': [compiler] + flags + [source]
+        }
+        compile_commands.append(command)
+
+with open(compile_commands_path, 'w') as file:
+    json.dump(compile_commands, file)

--- a/compile-commands.re.yml
+++ b/compile-commands.re.yml
@@ -1,0 +1,19 @@
+#
+# FROM TEMPLATE: re/compile-commands
+#
+# This template will add compile_commands generation to your Re target.
+# This lets tools such as clangd pick up the target and learn its properties.
+#
+# Consider adding `compile_commands.json` to your .gitignore.
+#
+
+actions:
+  - run:
+      on: meta-available
+      command: python
+      args:
+        [
+          "${root-dir}/compile-commands-gen.py",
+          "${root-dir}/.re-cache/meta/full.json",
+          "${root-dir}/compile_commands.json",
+        ]


### PR DESCRIPTION
- Added win32 process jobs to kill child process at the parent’s death
- Merged `RunProcessOrThrowWindows` and `RunProcessOrThrow` functions to `RunProcessOrThrow`
- Replaced `std::string_view` working directory type with `fs::path`
- Now Re doesn’t use reproc for processes on Windows